### PR TITLE
Fix message buffer leak

### DIFF
--- a/Client/WebSocketClientConnection.cs
+++ b/Client/WebSocketClientConnection.cs
@@ -75,10 +75,13 @@ public class WebSocketClientConnection : NetworkClientConnection
     
     private bool SendMessage(MessageBuffer message)
     {
-        if (_connectionState == ConnectionState.Disconnected)
+        if (_connectionState == ConnectionState.Disconnected) {
+            message.Dispose();
             return false;
+        }
         
         _webSocketClient.SendMessageToServer(message.Buffer, message.Count);
+        message.Dispose();
         return true;
     }
 


### PR DESCRIPTION
Seems like message buffers passed to `SendMessageReliable` and `SendMessageUnreliable` need to be disposed manually (see the `WebSocketSessionServerConnection` class). Otherwise, DarkRift will complain. This change should fix the problem.